### PR TITLE
Bullhead kernel: implement always on rgb led support

### DIFF
--- a/drivers/leds/leds-qpnp.c
+++ b/drivers/leds/leds-qpnp.c
@@ -1746,6 +1746,18 @@ static int rgb_duration_config(struct qpnp_led_data *led)
 
 	if (!on_ms) {
 		return -EINVAL;
+	} else if (!off_ms) {
+		/* implement always on
+		 * note:
+		 * rgb_on_off_ms_store() bumps on_ms=0 up to RGB_LED_MIN_MS
+		 * so setting ms on/off to 0/0 in /sys results in seeing
+		 * 50/0 by the time we get here
+		 */
+		ramp_step_ms = 1000;
+		num_duty_pcts = 1;
+		pwm_cfg->duty_cycles->duty_pcts[0] =
+			(led->cdev.brightness *
+			100) / RGB_MAX_LEVEL;
 	} else {
 		ramp_step_ms = on_ms / 20;
 		ramp_step_ms = (ramp_step_ms < 5)? 5 : ramp_step_ms;
@@ -2839,7 +2851,7 @@ static ssize_t rgb_start_store(struct device *dev,
 				dev_err(led_array[i].cdev.dev,
 					"RGB set rgb start failed (%d)\n", ret);
 			if (!(led_array[i].rgb_cfg->pwm_cfg->lut_params.flags &
-							PM_PWM_LUT_LOOP))
+							PM_PWM_LUT_RAMP_UP))
 				led_array[i].rgb_cfg->start = 0;
 			break;
 		default:


### PR DESCRIPTION
Like good old brother, N5X needs this patch aswell for charging led fx.

Original commit for Hammerhead by sam3000 slightly modified for Bullhead.

Original msg:

```
When offms is set to 0, configure a single point
duty cycle at the desired led brightness.
```

Signed-off-by: atl4ntis <nope>

Change-Id: I93b61af52ee2f695035e7f5d78814251c8d1da8d
